### PR TITLE
Add theme check and get repo from context

### DIFF
--- a/src/create-preview-links.ts
+++ b/src/create-preview-links.ts
@@ -7,12 +7,21 @@ interface ThemeZipFile {
 	url: string;
 }
 
+interface PluginZipFile {
+	resource: string;
+	slug: string;
+}
+
 interface Step {
 	step: string;
 	username?: string;
 	password?: string;
 	themeZipFile?: ThemeZipFile;
+	pluginZipFile?: PluginZipFile;
 	themeFolderName?: string;
+	options?: {
+		activate?: boolean;
+	};
 }
 
 interface Template {
@@ -36,6 +45,16 @@ function createBlueprint(themeSlug: string, branch: string): string {
 				step: 'login',
 				username: 'admin',
 				password: 'password',
+			},
+			{
+				step: 'installPlugin',
+				pluginZipFile: {
+					resource: 'wordpress.org/plugins',
+					slug: 'theme-check',
+				},
+				options: {
+					activate: true,
+				},
 			},
 			{
 				step: 'installTheme',

--- a/src/create-preview-links.ts
+++ b/src/create-preview-links.ts
@@ -37,7 +37,11 @@ export const COMMENT_BLOCK_START = '### Preview changes';
  * @param {string} branch - The branch where the theme changes are located.
  * @returns {string} - A JSON string representing the blueprint.
  */
-function createBlueprint(themeSlug: string, branch: string): string {
+function createBlueprint(
+	themeSlug: string,
+	branch: string,
+	repo: string,
+): string {
 	debug(`Creating blueprint for themeSlug: ${themeSlug}, branch: ${branch}`);
 	const template: Template = {
 		steps: [
@@ -60,7 +64,7 @@ function createBlueprint(themeSlug: string, branch: string): string {
 				step: 'installTheme',
 				themeZipFile: {
 					resource: 'url',
-					url: `https://github-proxy.com/proxy.php?action=partial&repo=Automattic/themes&directory=${themeSlug}&branch=${branch}`,
+					url: `https://github-proxy.com/proxy.php?action=partial&repo=${repo}&directory=${themeSlug}&branch=${branch}`,
 				},
 			},
 			{
@@ -102,11 +106,13 @@ export default async function createPreviewLinksComment(
 		.map(([themeName, themeDir]) => {
 			const themeSlug = themeDir.split('/')[0].trim();
 			const parentThemeSlug = themeName.split('_childof_')[1];
+			const repo = `${context.repo.owner}/${context.repo.repo}`;
 			return `- [Preview changes for **${
 				themeName.split('_childof_')[0]
 			}**](https://playground.wordpress.net/#${createBlueprint(
 				themeSlug,
 				pullRequest.head.ref,
+				repo,
 			)})${parentThemeSlug ? ` (child of **${parentThemeSlug}**)` : ''}`;
 		})
 		.join('\n');

--- a/src/create-preview-links.ts
+++ b/src/create-preview-links.ts
@@ -35,6 +35,7 @@ export const COMMENT_BLOCK_START = '### Preview changes';
  *
  * @param {string} themeSlug - The slug of the theme to create a blueprint for.
  * @param {string} branch - The branch where the theme changes are located.
+ * @param {string} repo - The repository where the theme changes are located, in the format 'owner/repo'.
  * @returns {string} - A JSON string representing the blueprint.
  */
 function createBlueprint(
@@ -42,7 +43,9 @@ function createBlueprint(
 	branch: string,
 	repo: string,
 ): string {
-	debug(`Creating blueprint for themeSlug: ${themeSlug}, branch: ${branch}`);
+	debug(
+		`Creating blueprint for themeSlug: ${themeSlug}, branch: ${branch}, repo: ${repo}`,
+	);
 	const template: Template = {
 		steps: [
 			{


### PR DESCRIPTION
Adding this step will enable the theme check plugin in the Playground instance, enabling us to check whether the theme is fit to be published in the WordPress.org theme directory.

I'm also fixing an oversight where the repo where this could run was hardcoded.